### PR TITLE
Replace EventSource state polling with HTTP polling; add connection status indicator

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -24,6 +24,10 @@
     isOpen = event.detail.isOpen;
   }
 
+  type ConnectionStatus = 'pending' | 'connected' | 'error';
+  let connectionStatus: ConnectionStatus = $state('pending');
+  let lastStatusCode: number | null = $state(null);
+
   // start gathering logs
   // stock esphome
   const esphome = new EventSource(import.meta.env.VITE_KILN_URL + "events");
@@ -60,11 +64,14 @@
     pollInterval = setInterval(async () => {
       try {
         const res = await fetch(import.meta.env.VITE_KILN_URL + "kiln/state");
+        lastStatusCode = res.status;
         if (res.ok) {
+          connectionStatus = 'connected';
           $current_state = await res.json();
         }
       } catch (e) {
-        // device unreachable — keep last known state
+        connectionStatus = 'error';
+        lastStatusCode = null;
       }
     }, 1000);
   });
@@ -88,6 +95,11 @@
         </NavItem>
         <NavItem>
           <NavLink href="https://github.com/kiln-controller"><Icon name="github" /></NavLink>
+        </NavItem>
+        <NavItem title="API: {import.meta.env.VITE_KILN_URL}kiln/state{lastStatusCode ? ' (HTTP ' + lastStatusCode + ')' : ''}">
+          <span class="nav-link">
+            <Icon name="circle-fill" class={connectionStatus === 'connected' ? 'text-success' : connectionStatus === 'error' ? 'text-danger' : 'text-secondary'} />
+          </span>
         </NavItem>
       </Nav>
     </Collapse>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
   import Router from 'svelte-spa-router';
   import {link} from 'svelte-spa-router';
   import active from 'svelte-spa-router/active'
@@ -26,7 +27,6 @@
   // start gathering logs
   // stock esphome
   const esphome = new EventSource(import.meta.env.VITE_KILN_URL + "events");
-  const kiln_api = new EventSource(import.meta.env.VITE_KILN_URL + "kiln/state");
   // https://esphome.io/web-api/#event-source-api
   esphome.addEventListener("log", (e: MessageEvent) => {
     // https://github.com/esphome/esphome-webserver/blob/main/v2/esp-log.ts#L21
@@ -53,10 +53,23 @@
     $stored_logs.unshift(record);
     $stored_logs = $stored_logs;
   });
-  kiln_api.addEventListener("state", (e: MessageEvent) => {
-    console.log(e.data);
-    $current_state = JSON.parse(e.data);
+
+  let pollInterval: ReturnType<typeof setInterval>;
+
+  onMount(() => {
+    pollInterval = setInterval(async () => {
+      try {
+        const res = await fetch(import.meta.env.VITE_KILN_URL + "kiln/state");
+        if (res.ok) {
+          $current_state = await res.json();
+        }
+      } catch (e) {
+        // device unreachable — keep last known state
+      }
+    }, 1000);
   });
+
+  onDestroy(() => clearInterval(pollInterval));
 </script>
 
 <main style="height: 100vh">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,12 @@ export default defineConfig(({ mode }) => {
       '/api': {
         target: env.KILN_DEVICE_URL,
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, '')
+        rewrite: (path) => path.replace(/^\/api/, ''),
+        configure: (proxy) => {
+          proxy.on('proxyReq', (proxyReq) => {
+            proxyReq.removeHeader('if-none-match')
+          })
+        }
       }
     } : undefined
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,20 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
   plugins: [svelte()],
+  server: {
+    proxy: env.KILN_DEVICE_URL ? {
+      '/api': {
+        target: env.KILN_DEVICE_URL,
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, '')
+      }
+    } : undefined
+  },
   build: {
     sourcemap: true,
     // https://github.com/vitejs/vite/issues/378#issuecomment-768816653
@@ -15,4 +26,4 @@ export default defineConfig({
       }
     }
   }
-})
+}})


### PR DESCRIPTION
- The ESP-IDF web server doesn't support the ESPHome EventSource API for kiln state (`/kiln/state`), so the SSE-based state listener has been replaced with a 1-second `setInterval` fetch loop.

- A connection status indicator (`pending` / `connected` / `error`) has been added to the navbar, showing the last HTTP status code on hover.

- The Vite dev proxy has been updated to:
  - Load the target URL from the `KILN_DEVICE_URL` environment variable
  - Strip `If-None-Match` headers from proxied requests, preventing the ESP32's ETag `304` responses from causing proxy `500` errors during local development
